### PR TITLE
Remove dust avoidance for OP_RETURN output

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 var databutton = {
   build: function(o) {
     datacash.build({ "data": o.data }, function(err, tx) {
-      var dust = 0.00000546;
       var s = tx.outputs[0]._script.toASM();
       var el = o.button.$el;
       var config = o.button;
-      config.outputs = [{ script: s, amount: dust, currency: 'BCH' }];
+      config.outputs = [{ script: s, amount: 0, currency: 'BCH' }];
       if (o.button && o.button.$cash && o.button.$cash.to) {
         o.button.$cash.to.forEach(function(receiver) {
           config.outputs.push({ to: receiver.address, amount: receiver.value/100000000, currency: 'BCH' })


### PR DESCRIPTION
OP_RETURN outputs don't require a non-dust output value.  If a non-zero
value is put into the output, the amount becomes unspendable and lost
forever.

I've tested the change with a small html file which I have not included in the pull request at this time.  The results of the test can be found on memo.cash by searching for "sorry dave" and and viewing the tx on one of the block explorers.

One concern: the datacash code allows for arbitrary scripts to be passed in.  If something other than a dataout type script is given, then the zero value output would cause the tx to be rejected.
