### PR TITLE
Change datacash to datapay

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Datapay](https://github.com/unwriter/datapay) plugin to build Moneybutton
 Include 3 scripts, in the following order:
 
 ```
-<script src="https://api.moneybutton.com/moneybutton.js"></script>
+<script src="https://www.moneybutton.com/moneybutton.js"></script>
 <script src='https://unpkg.com/datapay'></script>
 <script src='https://unpkg.com/databutton'></script>
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Databutton
 
-A [Datacash](https://github.com/unwriter/datacash) plugin to build Moneybutton
+A [Datapay](https://github.com/unwriter/datapay) plugin to build Moneybutton
 
 ![code](./code.png)
 
@@ -10,13 +10,13 @@ Include 3 scripts, in the following order:
 
 ```
 <script src="https://api.moneybutton.com/moneybutton.js"></script>
-<script src='https://unpkg.com/datacash'></script>
+<script src='https://unpkg.com/datapay'></script>
 <script src='https://unpkg.com/databutton'></script>
 ```
 
 # Usage
 
-Similar to [datacash](https://github.com/unwriter/datacash) syntax, except that the `cash` part is replaced with `button`.
+Similar to [datapay](https://github.com/unwriter/datapay) syntax, except that the `pay` part is replaced with `button`.
 
 ```
 databutton.build({
@@ -63,10 +63,10 @@ databutton.build({
 
 ## 2. Add money transfer options
 
-You can also specify additional `cash` attribute to send money. This is possible through the `$cash` attribute.
+You can also specify additional `pay` attribute to send money. This is possible through the `$pay` attribute.
 
 
-Currently `$cash` only has only one attribute: `to`, which is equivalent to datacash's ["cash.to" attribute usage](https://github.com/unwriter/datacash#4-to).
+Currently `$pay` only has only one attribute: `to`, which is equivalent to datapay's ["pay.to" attribute usage](https://github.com/unwriter/datapay#4-to).
 
 Here's an example:
 
@@ -75,7 +75,7 @@ databutton.build({
   data: ["0x6d0c", "topic", "hello world"],
   button: {
     $el: "#button",
-    $cash: {
+    $pay: {
       to: [{
         address: "qq4kp3w3yhhvy4gm4jgeza4vus8vpxgrwc90n8rhxe",
         value: 100000

--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ var databutton = {
       var config = o.button;
       config.outputs = [{ script: s, amount: 0, currency: 'BSV' }];
       if (o.button && o.button.$pay && o.button.$pay.to) {
-        o.button.$cash.to.forEach(function(receiver) {
+        o.button.$pay.to.forEach(function(receiver) {
           config.outputs.push({ to: receiver.address, amount: receiver.value/100000000, currency: 'BSV' })
         })
       }
       delete config.$el;
-      delete config.$cash;
+      delete config.$pay;
       moneyButton.render(
         (el instanceof Element ? el : document.querySelector(el)),
         config

--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 var databutton = {
   build: function(o) {
-    datacash.build({ "data": o.data }, function(err, tx) {
-      var dust = 0.00000546;
+    datapay.build({ "data": o.data }, function(err, tx) {
       var s = tx.outputs[0]._script.toASM();
       var el = o.button.$el;
       var config = o.button;
-      config.outputs = [{ script: s, amount: dust, currency: 'BCH' }];
-      if (o.button && o.button.$cash && o.button.$cash.to) {
+      config.outputs = [{ script: s, amount: 0, currency: 'BSV' }];
+      if (o.button && o.button.$pay && o.button.$pay.to) {
         o.button.$cash.to.forEach(function(receiver) {
-          config.outputs.push({ to: receiver.address, amount: receiver.value/100000000, currency: 'BCH' })
+          config.outputs.push({ to: receiver.address, amount: receiver.value/100000000, currency: 'BSV' })
         })
       }
       delete config.$el;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "databutton",
   "version": "0.0.1",
-  "description": "A Datacash plugin to build Moneybutton",
+  "description": "A Datapay plugin to build Moneybutton",
   "main": "index.js",
   "unpkg": "./index.js",
   "author": "",


### PR DESCRIPTION
Since moneybutton is sending the transaction anyway this change should not adversely affect anyone. Moneybutton is going to send using BSV anyway.

This change integrates the other pull request for removing the dust payment from the op_return output